### PR TITLE
Hide conference details and tagline on homepage

### DIFF
--- a/RAISQE'26/index.html
+++ b/RAISQE'26/index.html
@@ -86,8 +86,8 @@
             <button class="conf-btn">DOWNLOAD BROCHURE</button>
           </div>
           <div class="conf-info-card">
-            <h2 class="conf-info-heading">Conference Details</h2>
-            <p class="conf-info-text">Date: 23rd – 24th July 2026</p>
+            <!-- <h2 class="conf-info-heading">Conference Details</h2> -->
+            <!-- <p class="conf-info-text">Date: 23rd – 24th July 2026</p> -->
             <h2 class="conf-info-heading">Location</h2>
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3888.754334974239!2d77.49369877649256!3d12.923504783435844!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x3bafad1d6f18a4b9%3A0xc6082c1a24eba0bf!2sRV%20University!5e0!3m2!1sen!2sin!4v1748930222409!5m2!1sen!2sin"

--- a/RAISQE'26/style.css
+++ b/RAISQE'26/style.css
@@ -76,6 +76,7 @@ body {
 .tagline {
   font-size: 0.6rem;
   color: #4b4b4b;
+  display: none;
 }
 
 /* .rvu-logo {


### PR DESCRIPTION
Commented out the conference details section in index.html and set the .tagline class to display: none in style.css to hide it from view.